### PR TITLE
Add core math helpers with tests for pots and VPIP stats

### DIFF
--- a/src/models/Pot.ts
+++ b/src/models/Pot.ts
@@ -1,3 +1,5 @@
+import { calculateSidePots } from '../utils/potUtils';
+
 export interface Pot {
   id: string;
   amount: number;
@@ -23,52 +25,7 @@ export class PotManager {
   }
 
   createSidePots(players: any[]): void {
-    // Only create side pots if there's an all-in player
-    const hasAllIn = players.some(p => p.status === 'all_in');
-    if (!hasAllIn) {
-      // Just create a single main pot with all contributions
-      this.pots = [{
-        id: Math.random().toString(36).substr(2, 9),
-        amount: this.totalPot,
-        eligiblePlayers: Array.from(this.playerContributions.keys()),
-        isMain: true
-      }];
-      return;
-    }
-    
-    this.pots = [];
-    
-    // Get all contribution amounts and sort them
-    const contributions = Array.from(this.playerContributions.entries())
-      .filter(([id, amount]) => amount > 0)
-      .sort((a, b) => a[1] - b[1]);
-    
-    if (contributions.length === 0) return;
-    
-    let previousAmount = 0;
-    const processedAmounts = new Set<number>();
-    
-    for (const [, contributionAmount] of contributions) {
-      if (processedAmounts.has(contributionAmount)) continue;
-      processedAmounts.add(contributionAmount);
-      
-      const potAmount = contributionAmount - previousAmount;
-      const eligiblePlayers = contributions
-        .filter(([id, amount]) => amount >= contributionAmount)
-        .map(([id]) => id);
-      
-      if (potAmount > 0 && eligiblePlayers.length > 0) {
-        const pot: Pot = {
-          id: Math.random().toString(36).substr(2, 9),
-          amount: potAmount * eligiblePlayers.length,
-          eligiblePlayers,
-          isMain: this.pots.length === 0
-        };
-        this.pots.push(pot);
-      }
-      
-      previousAmount = contributionAmount;
-    }
+    this.pots = calculateSidePots(this.playerContributions, players);
   }
 
   distributePots(winners: { [potId: string]: string[] }): any[] {

--- a/src/utils/potUtils.test.ts
+++ b/src/utils/potUtils.test.ts
@@ -1,0 +1,48 @@
+import { calculateSidePots } from './potUtils';
+import { PlayerStatus } from '../models/Player';
+
+describe('calculateSidePots', () => {
+  test('returns single main pot when no all-ins', () => {
+    const contributions = new Map([
+      ['a', 100],
+      ['b', 100],
+      ['c', 100],
+    ]);
+    const players = [
+      { id: 'a', status: PlayerStatus.ACTIVE },
+      { id: 'b', status: PlayerStatus.ACTIVE },
+      { id: 'c', status: PlayerStatus.ACTIVE },
+    ];
+
+    const pots = calculateSidePots(contributions, players);
+    expect(pots).toHaveLength(1);
+    expect(pots[0].amount).toBe(300);
+    expect(pots[0].eligiblePlayers).toEqual(expect.arrayContaining(['a', 'b', 'c']));
+    expect(pots[0].isMain).toBe(true);
+  });
+
+  test('creates side pot when a player is all-in', () => {
+    const contributions = new Map([
+      ['a', 50],
+      ['b', 100],
+      ['c', 100],
+    ]);
+    const players = [
+      { id: 'a', status: PlayerStatus.ALL_IN },
+      { id: 'b', status: PlayerStatus.ACTIVE },
+      { id: 'c', status: PlayerStatus.ACTIVE },
+    ];
+
+    const pots = calculateSidePots(contributions, players);
+    expect(pots).toHaveLength(2);
+
+    const mainPot = pots[0];
+    const sidePot = pots[1];
+
+    expect(mainPot.amount).toBe(150);
+    expect(mainPot.eligiblePlayers).toEqual(expect.arrayContaining(['a', 'b', 'c']));
+    expect(sidePot.amount).toBe(100);
+    expect(sidePot.eligiblePlayers).toEqual(expect.arrayContaining(['b', 'c']));
+    expect(sidePot.eligiblePlayers).not.toContain('a');
+  });
+});

--- a/src/utils/potUtils.ts
+++ b/src/utils/potUtils.ts
@@ -1,0 +1,47 @@
+import { Pot } from '../models/Pot';
+import { PlayerStatus } from '../models/Player';
+
+/**
+ * Calculate main and side pots based on player contributions.
+ * Ensures side pots only include players who contributed to that level.
+ */
+export function calculateSidePots(
+  contributions: Map<string, number>,
+  players: { id: string; status: PlayerStatus }[]
+): Pot[] {
+  const entries = Array.from(contributions.entries()).filter(([, amount]) => amount > 0);
+  const hasAllIn = players.some(p => p.status === PlayerStatus.ALL_IN);
+
+  if (!hasAllIn) {
+    const total = entries.reduce((sum, [, amount]) => sum + amount, 0);
+    return [
+      {
+        id: Math.random().toString(36).substr(2, 9),
+        amount: total,
+        eligiblePlayers: entries.map(([id]) => id),
+        isMain: true,
+      },
+    ];
+  }
+
+  const pots: Pot[] = [];
+  const sorted = entries.sort((a, b) => a[1] - b[1]);
+  const levels = Array.from(new Set(sorted.map(([, amt]) => amt)));
+  let previous = 0;
+
+  for (const level of levels) {
+    const eligible = sorted.filter(([, amt]) => amt >= level).map(([id]) => id);
+    const potAmount = (level - previous) * eligible.length;
+    if (potAmount > 0 && eligible.length > 0) {
+      pots.push({
+        id: Math.random().toString(36).substr(2, 9),
+        amount: potAmount,
+        eligiblePlayers: eligible,
+        isMain: pots.length === 0,
+      });
+    }
+    previous = level;
+  }
+
+  return pots;
+}

--- a/src/utils/statsUtils.test.ts
+++ b/src/utils/statsUtils.test.ts
@@ -1,0 +1,38 @@
+import { isVPIPAction, updateVPIP, VPIPStats } from './statsUtils';
+import { Player } from '../models/Player';
+import { ActionType } from '../models/Game';
+
+const createPlayer = (opts: Partial<Player> = {}) => {
+  const p = new Player({ name: 'Test', seatNumber: 1, stack: 100 });
+  Object.assign(p, opts);
+  return p;
+};
+
+describe('isVPIPAction', () => {
+  test('big blind check with no raise does not count', () => {
+    const player = createPlayer({ isBigBlind: true });
+    const result = isVPIPAction(player, ActionType.CHECK, 10, 10, 0);
+    expect(result).toBe(false);
+  });
+
+  test('big blind call after raise counts', () => {
+    const player = createPlayer({ isBigBlind: true });
+    const result = isVPIPAction(player, ActionType.CALL, 20, 10, 0);
+    expect(result).toBe(true);
+  });
+
+  test('post-flop actions do not count', () => {
+    const player = createPlayer();
+    const result = isVPIPAction(player, ActionType.BET, 10, 10, 1);
+    expect(result).toBe(false);
+  });
+});
+
+describe('updateVPIP', () => {
+  test('increments handsVoluntarilyPlayed and vpip', () => {
+    const stats: VPIPStats = { handsPlayed: 2, handsVoluntarilyPlayed: 1, vpip: 50 };
+    updateVPIP(stats, true);
+    expect(stats.handsVoluntarilyPlayed).toBe(2);
+    expect(stats.vpip).toBe(100);
+  });
+});

--- a/src/utils/statsUtils.ts
+++ b/src/utils/statsUtils.ts
@@ -1,0 +1,32 @@
+import { ActionType } from '../models/Game';
+import { Player } from '../models/Player';
+
+export interface VPIPStats {
+  handsPlayed: number;
+  handsVoluntarilyPlayed: number;
+  vpip: number;
+}
+
+/** Determine if an action should count toward VPIP */
+export function isVPIPAction(
+  player: Player,
+  action: ActionType,
+  currentBet: number,
+  bigBlind: number,
+  currentRound: number
+): boolean {
+  if (currentRound !== 0) return false; // only pre-flop
+  if (action === ActionType.FOLD) return false;
+  if (player.isBigBlind && action === ActionType.CHECK && currentBet === bigBlind) {
+    return false; // BB check when no raise
+  }
+  return [ActionType.BET, ActionType.CALL, ActionType.RAISE, ActionType.ALL_IN].includes(action);
+}
+
+/** Update VPIP stats when a qualifying action occurs */
+export function updateVPIP(stats: VPIPStats, didVPIP: boolean): void {
+  if (didVPIP) {
+    stats.handsVoluntarilyPlayed += 1;
+    stats.vpip = Math.round((stats.handsVoluntarilyPlayed / stats.handsPlayed) * 100);
+  }
+}


### PR DESCRIPTION
## Summary
- add `calculateSidePots` helper and tests to verify main/side pot eligibility
- introduce VPIP helpers (`isVPIPAction`, `updateVPIP`) and integrate into game store
- refactor PotManager and game store to use new helpers and track voluntary action counts

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c08dfd8224832db21aefbca3334fbf