### PR TITLE
Fix overlapping UI elements and adjust game header size

### DIFF
--- a/src/components/GameScreen.css
+++ b/src/components/GameScreen.css
@@ -70,6 +70,17 @@
   text-align: center;
 }
 
+.header-center h1 {
+  font-size: 24px;
+  margin: 0;
+}
+
+@media (max-width: 412px) {
+  .header-center h1 {
+    font-size: 18px;
+  }
+}
+
 .back-button, .undo-button, .save-button, .load-button, .stats-button {
   padding: 8px 16px;
   background: #333;
@@ -235,7 +246,7 @@
   display: flex;
   overflow-x: auto;
   gap: 15px;
-  margin-bottom: 30px;
+  margin-bottom: 200px; /* prevent bottom action bar from covering last player */
   padding-bottom: 10px;
   padding-right: 50px; /* Increased buffer after last player */
   -webkit-overflow-scrolling: touch;
@@ -263,7 +274,7 @@
 @media (max-width: 412px) {
   .players-container {
     gap: 10px;
-    margin-bottom: 80px;
+    margin-bottom: 220px; /* extra space for fixed action bar on small screens */
     display: grid;
     grid-template-columns: 1fr 1fr;
     overflow-x: visible;

--- a/src/components/PlayerCard.css
+++ b/src/components/PlayerCard.css
@@ -102,7 +102,7 @@
 .current-indicator {
   position: absolute;
   top: 50%;
-  right: -10px;
+  right: -40px;
   transform: translateY(-50%);
   background: #4CAF50;
   color: white;
@@ -115,7 +115,7 @@
 
 @media (max-width: 412px) {
   .current-indicator {
-    right: -5px;
+    right: -30px;
     padding: 3px 6px;
     font-size: 10px;
   }


### PR DESCRIPTION
## Summary
- prevent bottom action bar from covering player list by adding extra margin
- relocate "TO ACT" marker to avoid overlapping player stacks
- shrink game name header for a cleaner layout

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c08f11cd94832db921706b39610a97