### PR TITLE
Enable pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,3 +54,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          enablement: true


### PR DESCRIPTION
## Summary
- enable GitHub Pages build by adding enablement flag to deploy action

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0943a3628832dbacce70661910dc2