### PR TITLE
Enable GitHub Pages site in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: enable
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- ensure GitHub Pages site is enabled during deploy

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c097360b98832da46adb507e088abe