### PR TITLE
Prevent creation of redundant side pots

### DIFF
--- a/src/utils/potUtils.test.ts
+++ b/src/utils/potUtils.test.ts
@@ -45,4 +45,21 @@ describe('calculateSidePots', () => {
     expect(sidePot.eligiblePlayers).toEqual(expect.arrayContaining(['b', 'c']));
     expect(sidePot.eligiblePlayers).not.toContain('a');
   });
+
+  test('does not create redundant side pot when all-in is fully called', () => {
+    const contributions = new Map([
+      ['a', 50],
+      ['b', 50],
+    ]);
+    const players = [
+      { id: 'a', status: PlayerStatus.ALL_IN },
+      { id: 'b', status: PlayerStatus.ACTIVE },
+    ];
+
+    const pots = calculateSidePots(contributions, players);
+    expect(pots).toHaveLength(1);
+    expect(pots[0].amount).toBe(100);
+    expect(pots[0].eligiblePlayers).toEqual(expect.arrayContaining(['a', 'b']));
+    expect(pots[0].isMain).toBe(true);
+  });
 });

--- a/src/utils/potUtils.ts
+++ b/src/utils/potUtils.ts
@@ -33,12 +33,22 @@ export function calculateSidePots(
     const eligible = sorted.filter(([, amt]) => amt >= level).map(([id]) => id);
     const potAmount = (level - previous) * eligible.length;
     if (potAmount > 0 && eligible.length > 0) {
-      pots.push({
-        id: Math.random().toString(36).substr(2, 9),
-        amount: potAmount,
-        eligiblePlayers: eligible,
-        isMain: pots.length === 0,
-      });
+      const prev = pots[pots.length - 1];
+      const sameAsPrevious =
+        prev &&
+        prev.eligiblePlayers.length === eligible.length &&
+        eligible.every(id => prev.eligiblePlayers.includes(id));
+
+      if (sameAsPrevious) {
+        prev.amount += potAmount;
+      } else {
+        pots.push({
+          id: Math.random().toString(36).substr(2, 9),
+          amount: potAmount,
+          eligiblePlayers: eligible,
+          isMain: pots.length === 0,
+        });
+      }
     }
     previous = level;
   }


### PR DESCRIPTION
## Summary
- guard against generating side pots with the same eligible players as the previous pot
- add regression test for all-in call creating only a single main pot

## Testing
- `CI=true npm test -- src/utils/potUtils.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c09a96573c832d9ede62f6cbaa62eb