### PR TITLE
Allow seat reordering and manual dealer selection

### DIFF
--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Player, PlayerStatus } from '../models/Player';
 import useGameStore from '../store/gameStore';
 import { GameStatus } from '../models/Game';
@@ -10,10 +10,19 @@ interface PlayerCardProps {
 }
 
 const PlayerCard: React.FC<PlayerCardProps> = ({ player, isCurrentTurn }) => {
-  const { currentGame, editPlayerStack, rebuyPlayer } = useGameStore();
+  const { currentGame, editPlayerStack, rebuyPlayer, movePlayerSeat, setDealer } = useGameStore();
   const [showEditModal, setShowEditModal] = useState(false);
   const [editAmount, setEditAmount] = useState(player.stack.toString());
   const [rebuyAmount, setRebuyAmount] = useState('1000');
+  const [editSeat, setEditSeat] = useState(player.seatNumber.toString());
+
+  useEffect(() => {
+    setEditAmount(player.stack.toString());
+  }, [player.stack]);
+
+  useEffect(() => {
+    setEditSeat(player.seatNumber.toString());
+  }, [player.seatNumber]);
   const getBadges = () => {
     const badges = [];
     if (player.isDealer) badges.push('D');
@@ -57,6 +66,19 @@ const PlayerCard: React.FC<PlayerCardProps> = ({ player, isCurrentTurn }) => {
     }
   };
 
+  const handleSeatChange = () => {
+    const seat = parseInt(editSeat);
+    if (!isNaN(seat) && seat >= 1) {
+      movePlayerSeat(player.id, seat);
+      setShowEditModal(false);
+    }
+  };
+
+  const handleSetDealer = () => {
+    setDealer(player.id);
+    setShowEditModal(false);
+  };
+
   const canEdit = currentGame?.status !== GameStatus.IN_PROGRESS;
 
   return (
@@ -66,7 +88,7 @@ const PlayerCard: React.FC<PlayerCardProps> = ({ player, isCurrentTurn }) => {
         onClick={() => canEdit && setShowEditModal(true)}
       >
         <div className="player-header">
-          <span className="player-name">{player.name}</span>
+          <span className="player-name">{player.seatNumber}. {player.name}</span>
           <div className="player-badges">
             {getBadges().map(badge => (
               <span key={badge} className="badge">{badge}</span>
@@ -111,8 +133,24 @@ const PlayerCard: React.FC<PlayerCardProps> = ({ player, isCurrentTurn }) => {
       {showEditModal && (
         <div className="modal-overlay" onClick={() => setShowEditModal(false)}>
           <div className="modal-content" onClick={e => e.stopPropagation()}>
-            <h3>Edit {player.name}'s Stack</h3>
-            
+            <h3>Edit {player.name}</h3>
+
+            <div className="edit-section">
+              <label>Move to Seat:</label>
+              <input
+                type="number"
+                value={editSeat}
+                onChange={e => setEditSeat(e.target.value)}
+                min="1"
+                max={currentGame?.maxPlayers}
+              />
+              <button onClick={handleSeatChange} className="confirm">Move Seat</button>
+            </div>
+
+            <div className="edit-section">
+              <button onClick={handleSetDealer} className="confirm">Make Dealer</button>
+            </div>
+
             <div className="edit-section">
               <label>Set Stack To:</label>
               <input

--- a/src/models/Game.seating.test.ts
+++ b/src/models/Game.seating.test.ts
@@ -1,0 +1,31 @@
+import { Game } from './Game';
+
+describe('Seat and dealer management', () => {
+  test('movePlayerSeat swaps seats and updates dealer position', () => {
+    const game = new Game();
+    const alice = game.addPlayer('Alice', 1);
+    const bob = game.addPlayer('Bob', 2);
+    const carol = game.addPlayer('Carol', 3);
+    game.setDealerButton(alice.id);
+
+    game.movePlayerSeat(alice.id, 3);
+
+    expect(alice.seatNumber).toBe(3);
+    expect(carol.seatNumber).toBe(1);
+    expect(game.players[0].id).toBe(carol.id);
+    expect(game.players[2].id).toBe(alice.id);
+    expect(game.dealerPosition).toBe(2);
+  });
+
+  test('setDealerButton sets dealer correctly', () => {
+    const game = new Game();
+    const alice = game.addPlayer('Alice', 1);
+    const bob = game.addPlayer('Bob', 2);
+
+    game.setDealerButton(bob.id);
+
+    expect(game.players[1].isDealer).toBe(true);
+    expect(game.players[0].isDealer).toBe(false);
+    expect(game.dealerPosition).toBe(1);
+  });
+});

--- a/src/models/Game.ts
+++ b/src/models/Game.ts
@@ -128,6 +128,36 @@ export class Game {
     this.players.sort((a, b) => a.seatNumber - b.seatNumber);
   }
 
+  movePlayerSeat(playerId: string, newSeat: number): void {
+    const player = this.players.find(p => p.id === playerId);
+    if (!player) {
+      throw new Error('Player not found');
+    }
+    if (newSeat < 1 || newSeat > this.maxPlayers) {
+      throw new Error('Invalid seat number');
+    }
+
+    const occupyingPlayer = this.players.find(p => p.seatNumber === newSeat);
+    if (occupyingPlayer) {
+      occupyingPlayer.seatNumber = player.seatNumber;
+    }
+
+    player.seatNumber = newSeat;
+    this.sortPlayersBySeat();
+    this.dealerPosition = this.players.findIndex(p => p.isDealer);
+  }
+
+  setDealerButton(playerId: string): void {
+    const index = this.players.findIndex(p => p.id === playerId);
+    if (index === -1) {
+      throw new Error('Player not found');
+    }
+
+    this.players.forEach(p => (p.isDealer = false));
+    this.players[index].isDealer = true;
+    this.dealerPosition = index;
+  }
+
   startHand(): void {
     if (this.getActivePlayers().length < 2) {
       throw new Error('Need at least 2 players to start');


### PR DESCRIPTION
## Summary
- add Game.movePlayerSeat and Game.setDealerButton to rearrange seats and manually choose dealer
- expose seat/dealer editing actions in game store and player card UI
- cover seating changes with new unit tests

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c09aba0218832dad1ce91ef552faa4