### PR TITLE
Improve stats modal readability on dark backgrounds

### DIFF
--- a/src/components/StatsModal.css
+++ b/src/components/StatsModal.css
@@ -37,15 +37,16 @@
 .stats-table td {
   padding: 10px 12px;
   border-bottom: 1px solid #ecf0f1;
+  color: white;
 }
 
-.stats-table tbody tr:hover {
-  background-color: #f8f9fa;
+.stats-table tbody tr {
+  pointer-events: none;
 }
 
 .stats-table .player-name {
   font-weight: 500;
-  color: #2c3e50;
+  color: white;
 }
 
 .stats-table .profit {


### PR DESCRIPTION
## Summary
- Ensure stats table text uses white for better contrast on dark modal background
- Disable stats row interactions to prevent white-on-white highlighting on tap

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c09a6ca9fc832d8798eb59f728fb2c