### PR TITLE
Fix VPIP calculation when folding

### DIFF
--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -279,6 +279,7 @@ const useGameStore = create<GameStore>()((set, get) => ({
             stats.handsVoluntarilyPlayed = 0;
           }
           stats.handsPlayed++;
+          updateVPIP(stats, false);
         });
         
         // Store the stacks before hand starts

--- a/src/store/gameStore.vpip.test.ts
+++ b/src/store/gameStore.vpip.test.ts
@@ -1,0 +1,48 @@
+import useGameStore from './gameStore';
+import { ActionType, BettingLimit } from '../models/Game';
+
+beforeEach(() => {
+  useGameStore.setState({
+    currentGame: null,
+    gameHistory: [],
+    historyIndex: -1,
+    savedGames: [],
+    playerStats: new Map(),
+    stacksBeforeHand: null
+  });
+  localStorage.clear();
+});
+
+describe('VPIP tracking across hands', () => {
+  test('VPIP decreases when player folds pre-flop', () => {
+    const store = useGameStore.getState();
+    store.createNewGame({ startingStack: 100, smallBlind: 5, bigBlind: 10, bettingLimit: BettingLimit.NO_LIMIT });
+    store.addPlayer('Alice');
+    store.addPlayer('Bob');
+    store.startHand();
+
+    let game = useGameStore.getState().currentGame!;
+    const bob = game.players.find(p => p.name === 'Bob')!; // dealer/SB
+    const alice = game.players.find(p => p.name === 'Alice')!; // BB
+
+    // Bob calls the big blind (counts toward VPIP)
+    store.performAction(bob.id, ActionType.CALL);
+    // Alice folds, ending the hand
+    store.performAction(alice.id, ActionType.FOLD);
+
+    // Start second hand
+    store.startHand();
+    game = useGameStore.getState().currentGame!;
+    const alice2 = game.players.find(p => p.name === 'Alice')!; // dealer/SB
+    const bob2 = game.players.find(p => p.name === 'Bob')!; // BB
+
+    // Alice raises, Bob folds without voluntarily putting chips in pot
+    store.performAction(alice2.id, ActionType.RAISE, game.bigBlind * 2);
+    store.performAction(bob2.id, ActionType.FOLD);
+
+    const bobStats = useGameStore.getState().playerStats.get('Bob')!;
+    expect(bobStats.handsPlayed).toBe(2);
+    expect(bobStats.handsVoluntarilyPlayed).toBe(1);
+    expect(bobStats.vpip).toBe(50);
+  });
+});

--- a/src/utils/statsUtils.test.ts
+++ b/src/utils/statsUtils.test.ts
@@ -26,6 +26,12 @@ describe('isVPIPAction', () => {
     const result = isVPIPAction(player, ActionType.BET, 10, 10, 1);
     expect(result).toBe(false);
   });
+
+  test('folding pre-flop does not count', () => {
+    const player = createPlayer();
+    const result = isVPIPAction(player, ActionType.FOLD, 10, 10, 0);
+    expect(result).toBe(false);
+  });
 });
 
 describe('updateVPIP', () => {
@@ -34,5 +40,13 @@ describe('updateVPIP', () => {
     updateVPIP(stats, true);
     expect(stats.handsVoluntarilyPlayed).toBe(2);
     expect(stats.vpip).toBe(100);
+  });
+
+  test('recalculates vpip when player does not VPIP', () => {
+    const stats: VPIPStats = { handsPlayed: 1, handsVoluntarilyPlayed: 1, vpip: 100 };
+    stats.handsPlayed++;
+    updateVPIP(stats, false);
+    expect(stats.handsVoluntarilyPlayed).toBe(1);
+    expect(stats.vpip).toBe(50);
   });
 });

--- a/src/utils/statsUtils.ts
+++ b/src/utils/statsUtils.ts
@@ -27,6 +27,10 @@ export function isVPIPAction(
 export function updateVPIP(stats: VPIPStats, didVPIP: boolean): void {
   if (didVPIP) {
     stats.handsVoluntarilyPlayed += 1;
+  }
+  if (stats.handsPlayed > 0) {
     stats.vpip = Math.round((stats.handsVoluntarilyPlayed / stats.handsPlayed) * 100);
+  } else {
+    stats.vpip = 0;
   }
 }


### PR DESCRIPTION
## Summary
- update VPIP stats calculation so folding hands lowers VPIP
- refresh player VPIP at start of each hand
- add unit tests for VPIP utilities and game store folding scenario

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c09d44f5f0832da0e4564485c110ba