### PR TITLE
Add persistent hand history and range-based statistics

### DIFF
--- a/src/components/StatsModal.css
+++ b/src/components/StatsModal.css
@@ -18,6 +18,17 @@
   -webkit-overflow-scrolling: touch;
 }
 
+.stats-range {
+  margin-top: 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.stats-range select {
+  padding: 4px 8px;
+}
+
 .stats-table table {
   width: 100%;
   min-width: 600px;

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import useGameStore from '../store/gameStore';
 import './StatsModal.css';
 
@@ -8,16 +8,31 @@ interface StatsModalProps {
 }
 
 const StatsModal: React.FC<StatsModalProps> = ({ show, onClose }) => {
-  const { getPlayerStats } = useGameStore();
-  
+  const { getHistoricalStats } = useGameStore();
+  const [range, setRange] = useState<string>('all');
+
   if (!show) return null;
-  
-  const stats = getPlayerStats();
+
+  const lastN = range === 'all' ? undefined : parseInt(range, 10);
+  const stats = getHistoricalStats(lastN);
   
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal-content stats-modal" onClick={(e) => e.stopPropagation()}>
         <h2>Player Statistics</h2>
+
+        <div className="stats-range">
+          <label htmlFor="stats-range-select">Show:</label>
+          <select
+            id="stats-range-select"
+            value={range}
+            onChange={(e) => setRange(e.target.value)}
+          >
+            <option value="all">All Hands</option>
+            <option value="100">Last 100 Hands</option>
+            <option value="500">Last 500 Hands</option>
+          </select>
+        </div>
         
         {stats.length === 0 ? (
           <p className="no-stats">No statistics available yet. Play some hands to see stats!</p>


### PR DESCRIPTION
## Summary
- Track detailed hand history with action stats and persist latest 1000 hands
- Compute player statistics over recent hands via new `getHistoricalStats` selector
- Allow selecting stat ranges (All, Last 100, Last 500 hands) in stats modal

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c09bb715f8832db2f1c58e4ba19d1f