### PR TITLE
Add scoped and global stats views

### DIFF
--- a/src/components/StatsModal.css
+++ b/src/components/StatsModal.css
@@ -29,6 +29,17 @@
   padding: 4px 8px;
 }
 
+.stats-scope {
+  margin-top: 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.stats-scope select {
+  padding: 4px 8px;
+}
+
 .stats-table table {
   width: 100%;
   min-width: 600px;

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -8,18 +8,31 @@ interface StatsModalProps {
 }
 
 const StatsModal: React.FC<StatsModalProps> = ({ show, onClose }) => {
-  const { getHistoricalStats } = useGameStore();
+  const { getHistoricalStats, getGameStats } = useGameStore();
   const [range, setRange] = useState<string>('all');
+  const [scope, setScope] = useState<string>('game');
 
   if (!show) return null;
 
   const lastN = range === 'all' ? undefined : parseInt(range, 10);
-  const stats = getHistoricalStats(lastN);
+  const stats = scope === 'all' ? getHistoricalStats(lastN) : getGameStats(lastN);
   
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal-content stats-modal" onClick={(e) => e.stopPropagation()}>
         <h2>Player Statistics</h2>
+
+        <div className="stats-scope">
+          <label htmlFor="stats-scope-select">Stats For:</label>
+          <select
+            id="stats-scope-select"
+            value={scope}
+            onChange={(e) => setScope(e.target.value)}
+          >
+            <option value="game">This Game</option>
+            <option value="all">All Games</option>
+          </select>
+        </div>
 
         <div className="stats-range">
           <label htmlFor="stats-range-select">Show:</label>

--- a/src/store/gameStore.vpip.test.ts
+++ b/src/store/gameStore.vpip.test.ts
@@ -8,7 +8,9 @@ beforeEach(() => {
     historyIndex: -1,
     savedGames: [],
     playerStats: new Map(),
-    stacksBeforeHand: null
+    stacksBeforeHand: null,
+    handHistory: [],
+    currentHandStats: null
   });
   localStorage.clear();
 });


### PR DESCRIPTION
## Summary
- allow switching between current game stats and all-time stats in StatsModal
- track gameId in hand history and expose `getGameStats` in store
- add CSS and tests updates for new stats scope

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c0a470a7b4832dadc571dda13cbd14