### PR TITLE
Fix TO ACT indicator overlapping player stack

### DIFF
--- a/src/components/PlayerCard.css
+++ b/src/components/PlayerCard.css
@@ -102,7 +102,8 @@
 .current-indicator {
   position: absolute;
   top: 50%;
-  right: -40px;
+  left: 100%;
+  margin-left: 10px;
   transform: translateY(-50%);
   background: #4CAF50;
   color: white;
@@ -115,7 +116,7 @@
 
 @media (max-width: 412px) {
   .current-indicator {
-    right: -30px;
+    margin-left: 6px;
     padding: 3px 6px;
     font-size: 10px;
   }


### PR DESCRIPTION
## Summary
- Reposition TO ACT badge outside the player card to prevent overlap with stack values

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c0c7647b9c832d94bb577b564f8150