### PR TITLE
Add hand history detail view to stats

### DIFF
--- a/src/components/StatsModal.css
+++ b/src/components/StatsModal.css
@@ -100,6 +100,15 @@
   font-weight: 600;
 }
 
+.hand-details {
+  margin-top: 20px;
+}
+
+.hand-detail h4 {
+  margin-bottom: 10px;
+  color: white;
+}
+
 /* Mobile responsive adjustments */
 @media (max-width: 768px) {
   .stats-modal {

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -7,15 +7,50 @@ interface StatsModalProps {
   onClose: () => void;
 }
 
+interface HandDetailsPlayer {
+  playerId: string;
+  playerName: string;
+  stackBefore: number;
+  profit: number;
+  won: boolean;
+  vpip: boolean;
+  actionStats: {
+    raises: number;
+    calls: number;
+    folds: number;
+    checks: number;
+    bets: number;
+    allIns: number;
+    raiseOpportunities: number;
+    callOpportunities: number;
+    foldOpportunities: number;
+    checkOpportunities: number;
+    betOpportunities: number;
+  };
+}
+
+interface HandDetailsEntry {
+  timestamp: number;
+  gameId?: string;
+  players: HandDetailsPlayer[];
+  winners: string[];
+}
+
 const StatsModal: React.FC<StatsModalProps> = ({ show, onClose }) => {
-  const { getHistoricalStats, getGameStats } = useGameStore();
+  const { getHistoricalStats, getGameStats, handHistory, currentGame } = useGameStore();
   const [range, setRange] = useState<string>('all');
   const [scope, setScope] = useState<string>('game');
+  const [showDetails, setShowDetails] = useState<boolean>(false);
 
   if (!show) return null;
 
   const lastN = range === 'all' ? undefined : parseInt(range, 10);
   const stats = scope === 'all' ? getHistoricalStats(lastN) : getGameStats(lastN);
+
+  const historyBase = scope === 'all'
+    ? handHistory
+    : handHistory.filter((h: HandDetailsEntry) => h.gameId === currentGame?.id);
+  const history: HandDetailsEntry[] = lastN ? historyBase.slice(-lastN) : historyBase;
   
   return (
     <div className="modal-overlay" onClick={onClose}>
@@ -123,8 +158,77 @@ const StatsModal: React.FC<StatsModalProps> = ({ show, onClose }) => {
             </div>
           </div>
         )}
-        
+
+        {showDetails && (
+          history.length === 0 ? (
+            <p className="no-stats">No hand history available.</p>
+          ) : (
+            <div className="hand-details">
+              <h3>Hand Details</h3>
+              {history.map((hand, index) => (
+                <div key={index} className="hand-detail">
+                  <h4>
+                    Hand {index + 1} - {new Date(hand.timestamp).toLocaleString()}
+                  </h4>
+                  <div className="stats-table">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Player</th>
+                          <th>Won</th>
+                          <th>Profit</th>
+                          <th>VPIP</th>
+                          <th>Raises</th>
+                          <th>Calls</th>
+                          <th>Folds</th>
+                          <th>Checks</th>
+                          <th>Bets</th>
+                          <th>All-Ins</th>
+                          <th>Raise Opp</th>
+                          <th>Call Opp</th>
+                          <th>Fold Opp</th>
+                          <th>Check Opp</th>
+                          <th>Bet Opp</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {hand.players.map((p) => {
+                          const profitClass = p.profit > 0 ? 'profit' : p.profit < 0 ? 'loss' : '';
+                          return (
+                            <tr key={p.playerId}>
+                              <td className="player-name">{p.playerName}</td>
+                              <td>{p.won ? 'Yes' : 'No'}</td>
+                              <td className={profitClass}>
+                                {p.profit > 0 ? '+' : ''}${p.profit}
+                              </td>
+                              <td>{p.vpip ? 'Yes' : 'No'}</td>
+                              <td>{p.actionStats.raises}</td>
+                              <td>{p.actionStats.calls}</td>
+                              <td>{p.actionStats.folds}</td>
+                              <td>{p.actionStats.checks}</td>
+                              <td>{p.actionStats.bets}</td>
+                              <td>{p.actionStats.allIns}</td>
+                              <td>{p.actionStats.raiseOpportunities}</td>
+                              <td>{p.actionStats.callOpportunities}</td>
+                              <td>{p.actionStats.foldOpportunities}</td>
+                              <td>{p.actionStats.checkOpportunities}</td>
+                              <td>{p.actionStats.betOpportunities}</td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )
+        )}
+
         <div className="modal-actions">
+          <button onClick={() => setShowDetails(d => !d)}>
+            {showDetails ? 'Hide Details' : 'Show Details'}
+          </button>
           <button onClick={onClose}>Close</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add show details toggle in stats modal to inspect per-hand action counts
- include hand history tables with counters driving each player's stats

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c0ca71da70832d8da0247de5c163b0