### PR TITLE
Make pot banner sticky and streamline action buttons

### DIFF
--- a/src/components/ActionButtons.css
+++ b/src/components/ActionButtons.css
@@ -112,16 +112,14 @@
 
 .action-button.all-in {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  width: 60%;
-  max-width: 250px;
-  margin: 20px auto 0;
+  margin-left: 20px;
+  padding: 12px 32px;
 }
 
 @media (max-width: 412px) {
   .action-button.all-in {
-    width: 80%;
-    max-width: 80%;
-    margin-top: 15px;
+    margin-left: 15px;
+    padding: 8px 20px;
   }
 }
 

--- a/src/components/ActionButtons.tsx
+++ b/src/components/ActionButtons.tsx
@@ -114,9 +114,13 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
       </div>
 
       <div className="button-row">
-        {canCheck && (
+        {canCheck ? (
           <button className="action-button check" onClick={() => onAction(ActionType.CHECK)}>
             CHECK
+          </button>
+        ) : (
+          <button className="action-button fold" onClick={() => onAction(ActionType.FOLD)}>
+            FOLD
           </button>
         )}
 
@@ -127,33 +131,32 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
           </button>
         )}
 
-        {canBet && (
-          <button className="action-button bet" onClick={() => setShowBetModal(true)}>
-            BET
+        {(canBet || canRaise) && (
+          <button
+            className={`action-button ${canBet ? 'bet' : 'raise'}`}
+            onClick={() => {
+              if (canBet) {
+                setShowBetModal(true);
+              } else {
+                setShowRaiseModal(true);
+              }
+            }}
+          >
+            {canBet ? 'BET' : 'RAISE'}
           </button>
         )}
 
-        {canRaise && (
-          <button className="action-button raise" onClick={() => setShowRaiseModal(true)}>
-            RAISE
+        {bettingLimit !== BettingLimit.FIXED_LIMIT && (
+          <button
+            className="action-button all-in"
+            onClick={() => onAction(ActionType.ALL_IN)}
+            disabled={currentPlayer.stack === 0}
+          >
+            <span>ALL IN</span>
+            <span className="amount">${currentPlayer.stack}</span>
           </button>
         )}
-
-        <button className="action-button fold" onClick={() => onAction(ActionType.FOLD)}>
-          FOLD
-        </button>
       </div>
-
-      {bettingLimit !== BettingLimit.FIXED_LIMIT && (
-        <button 
-          className="action-button all-in" 
-          onClick={() => onAction(ActionType.ALL_IN)}
-          disabled={currentPlayer.stack === 0}
-        >
-          <span>ALL IN</span>
-          <span className="amount">${currentPlayer.stack}</span>
-        </button>
-      )}
 
       {showBetModal && (
         <div className="modal-overlay" onClick={() => setShowBetModal(false)}>

--- a/src/components/GameScreen.css
+++ b/src/components/GameScreen.css
@@ -163,15 +163,18 @@
 .pot-container {
   background: #2a2a2a;
   border-radius: 8px;
-  padding: 20px;
-  margin-bottom: 30px;
+  padding: 15px 20px;
+  margin-bottom: 20px;
   text-align: center;
+  position: sticky;
+  top: 0;
+  z-index: 50;
 }
 
 @media (max-width: 412px) {
   .pot-container {
-    padding: 12px;
-    margin-bottom: 15px;
+    padding: 10px 12px;
+    margin-bottom: 12px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Keep pot banner visible by sticking it to the top during play
- Reorganize action controls into a single row with clearer ordering

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c0d08aad18832d872bf93781d103e2