### PR TITLE
feat: add more hand range options

### DIFF
--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -76,9 +76,10 @@ const StatsModal: React.FC<StatsModalProps> = ({ show, onClose }) => {
             value={range}
             onChange={(e) => setRange(e.target.value)}
           >
-            <option value="all">All Hands</option>
+            <option value="10">Last 10 Hands</option>
+            <option value="50">Last 50 Hands</option>
             <option value="100">Last 100 Hands</option>
-            <option value="500">Last 500 Hands</option>
+            <option value="all">All Hands</option>
           </select>
         </div>
         


### PR DESCRIPTION
## Summary
- show hand range options of 10, 50, 100, or all in stats modal

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c0d1265b98832d9a1e062ae223dc72