### PR TITLE
fix: remove configure-pages enablement input

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,8 +38,6 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
-        with:
-          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- drop configure-pages enablement input to rely on default behavior

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c0de10b258832d8e5097c3553be1b3