### PR TITLE
Fix pot banner stickiness and align fold button

### DIFF
--- a/src/components/ActionButtons.css
+++ b/src/components/ActionButtons.css
@@ -85,12 +85,18 @@
 .action-button .amount {
   font-size: 12px;
   opacity: 0.9;
+  min-height: 1em;
+  display: block;
 }
 
 @media (max-width: 412px) {
   .action-button .amount {
     font-size: 10px;
   }
+}
+
+.action-button.fold .amount {
+  visibility: hidden;
 }
 
 .action-button.check {

--- a/src/components/GameScreen.css
+++ b/src/components/GameScreen.css
@@ -163,18 +163,18 @@
 .pot-container {
   background: #2a2a2a;
   border-radius: 8px;
-  padding: 15px 20px;
+  padding: 10px 20px;
   margin-bottom: 20px;
   text-align: center;
-  position: sticky;
   position: -webkit-sticky;
+  position: sticky;
   top: 0;
   z-index: 100;
 }
 
 @media (max-width: 412px) {
   .pot-container {
-    padding: 10px 12px;
+    padding: 8px 12px;
     margin-bottom: 12px;
   }
 }


### PR DESCRIPTION
## Summary
- keep pot size banner visible during scrolling
- ensure fold button aligns with other action buttons

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c0e20b4728832d84a25195dc0b819c