### PR TITLE
Fix sticky header on mobile by removing global overflow constraints

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -16,7 +16,6 @@ body {
 .App {
   min-height: 100vh;
   width: 100%;
-  overflow-x: hidden;
 }
 
 /* Mobile optimizations */

--- a/src/components/GameScreen.css
+++ b/src/components/GameScreen.css
@@ -4,7 +4,6 @@
   color: white;
   padding: 20px;
   width: 100%;
-  overflow-x: hidden;
 }
 
 @media (max-width: 412px) {

--- a/src/index.css
+++ b/src/index.css
@@ -15,7 +15,6 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  overflow-x: hidden;
   width: 100%;
   min-height: 100vh;
 }
@@ -25,9 +24,7 @@ code {
     monospace;
 }
 
-/* Prevent horizontal scrolling */
 #root {
-  overflow-x: hidden;
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- allow sticky top bar by removing `overflow-x: hidden` from root containers

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17ba071fc832d9bca24cdc560cfb9