### PR TITLE
Add new game prompt and reset

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
       {currentScreen === 'setup' ? (
         <SetupScreen onGameCreated={() => setCurrentScreen('game')} />
       ) : (
-        <GameScreen />
+        <GameScreen onNewGame={() => setCurrentScreen('setup')} />
       )}
     </div>
   );

--- a/src/components/GameScreen.css
+++ b/src/components/GameScreen.css
@@ -88,7 +88,7 @@
   }
 }
 
-.back-button, .undo-button, .save-button, .load-button, .stats-button {
+.back-button, .undo-button, .save-button, .load-button, .stats-button, .new-game-button {
   padding: 8px 16px;
   background: #333;
   color: white;
@@ -100,14 +100,14 @@
 }
 
 @media (max-width: 412px) {
-  .back-button, .undo-button, .save-button, .load-button, .stats-button {
+  .back-button, .undo-button, .save-button, .load-button, .stats-button, .new-game-button {
     padding: 6px 10px;
     font-size: 12px;
   }
 }
 
-.back-button:hover, .undo-button:hover:not(:disabled), 
-.save-button:hover, .load-button:hover, .stats-button:hover {
+.back-button:hover, .undo-button:hover:not(:disabled),
+.save-button:hover, .load-button:hover, .stats-button:hover, .new-game-button:hover {
   background: #444;
 }
 
@@ -138,6 +138,14 @@
 
 .stats-button:hover {
   background: #F57C00;
+}
+
+.new-game-button {
+  background: #f44336;
+}
+
+.new-game-button:hover {
+  background: #d32f2f;
 }
 
 .game-header h1 {
@@ -433,15 +441,13 @@
   justify-content: flex-end;
 }
 
+
 .modal-actions button {
   padding: 10px 20px;
   border: none;
   border-radius: 6px;
   cursor: pointer;
   font-size: 16px;
-}
-
-.modal-actions button:first-child {
   background: #555;
   color: white;
 }


### PR DESCRIPTION
## Summary
- Add onNewGame support in App and GameScreen to allow starting a new game without reloading
- Introduce New Game button with save/don't save/keep playing prompt
- Style new button and modal actions

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c182d0b554832db815a0456a5a7249