### PR TITLE
Add option to prefill new game from last save

### DIFF
--- a/src/components/SetupScreen.css
+++ b/src/components/SetupScreen.css
@@ -53,8 +53,25 @@
   white-space: nowrap;
 }
 
+.prefill-button {
+  padding: 10px 20px;
+  background: #607D8B;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background 0.2s;
+  white-space: nowrap;
+}
+
 @media (max-width: 412px) {
   .load-game-button {
+    padding: 8px 12px;
+    font-size: 12px;
+  }
+
+  .prefill-button {
     padding: 8px 12px;
     font-size: 12px;
   }
@@ -62,6 +79,10 @@
 
 .load-game-button:hover {
   background: #7B1FA2;
+}
+
+.prefill-button:hover {
+  background: #455A64;
 }
 
 .form-section {

--- a/src/components/SetupScreen.tsx
+++ b/src/components/SetupScreen.tsx
@@ -39,6 +39,35 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onGameCreated }) => {
     setPlayers(newPlayers);
   };
 
+  const handlePrefill = () => {
+    const savedGames = getSavedGames();
+    if (savedGames.length === 0) return;
+
+    const lastGame = savedGames[savedGames.length - 1];
+    try {
+      const gameData = JSON.parse(lastGame.gameState);
+      setGameName(gameData.name || '');
+      setMaxPlayers(gameData.maxPlayers?.toString() || '9');
+      setStartingStack(gameData.startingStack?.toString() || '1000');
+      setSmallBlind(gameData.smallBlind?.toString() || '5');
+      setBigBlind(gameData.bigBlind?.toString() || '10');
+      setAnte(gameData.ante?.toString() || '0');
+      setBettingLimit(gameData.bettingLimit || BettingLimit.NO_LIMIT);
+      setTotalRounds(gameData.totalRounds?.toString() || '4');
+
+      if (Array.isArray(gameData.players)) {
+        setPlayers(
+          gameData.players.map((p: any) => ({
+            name: p.name || '',
+            stack: p.stack?.toString() || ''
+          }))
+        );
+      }
+    } catch (err) {
+      console.error('Failed to prefill from last saved game', err);
+    }
+  };
+
   const handleLoad = (saveId: string) => {
     loadGame(saveId);
     onGameCreated();
@@ -80,9 +109,14 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onGameCreated }) => {
       <div className="setup-header">
         <h1>New Game Setup</h1>
         {getSavedGames().length > 0 && (
-          <button className="load-game-button" onClick={() => setShowLoadModal(true)}>
-            📁 Load Saved Game
-          </button>
+          <>
+            <button className="prefill-button" onClick={handlePrefill}>
+              🔄 Use Last Game
+            </button>
+            <button className="load-game-button" onClick={() => setShowLoadModal(true)}>
+              📁 Load Saved Game
+            </button>
+          </>
         )}
       </div>
       


### PR DESCRIPTION
## Summary
- add 'Use Last Game' button on setup screen to pre-populate settings and players from the most recent save
- style new prefill button

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c183275094832d8a8c286f04e2c771