### PR TITLE
Show dealer before first hand starts

### DIFF
--- a/src/models/Game.dealer.test.ts
+++ b/src/models/Game.dealer.test.ts
@@ -7,7 +7,11 @@ describe('Dealer button movement', () => {
     const bob = game.addPlayer('Bob', 2);
     const carol = game.addPlayer('Carol', 3);
 
-    // First hand starts with Bob as dealer
+    // Dealer should be set before first hand starts (Bob)
+    expect(game.dealerPosition).toBe(1);
+    expect(bob.isDealer).toBe(true);
+
+    // Starting the first hand shouldn't change dealer
     game.startHand();
 
     expect(game.dealerPosition).toBe(1);

--- a/src/models/Game.ts
+++ b/src/models/Game.ts
@@ -100,6 +100,12 @@ export class Game {
 
     this.players.push(player);
     this.sortPlayersBySeat();
+    if (this.players.length >= 2 && !this.players.some(p => p.isDealer)) {
+      this.players[1].isDealer = true;
+      this.dealerPosition = 1;
+    } else {
+      this.dealerPosition = this.players.findIndex(p => p.isDealer);
+    }
     return player;
   }
 
@@ -184,7 +190,7 @@ export class Game {
       }
     });
 
-    if (this.handNumber === 1) {
+    if (!this.players.some(p => p.isDealer)) {
       this.moveDealerButton();
     }
     this.postBlindsAndAntes();


### PR DESCRIPTION
## Summary
- Assign dealer button once second player joins a game
- Start hand only moves dealer if none is set yet
- Update dealer rotation test for initial dealer visibility

## Testing
- `npm test -- --watchAll=false`
- `node test-betting-limits.mjs`
- `node test-hand-flow.js`
- `node test-game-flow.mjs`
- `node test-serialization.mjs`
- `node test_poker_app.js`
- `node test_poker_complete.js`
- `node test_poker_simple.js`


------
https://chatgpt.com/codex/tasks/task_e_68c18fc8f3a0832db33a2192a4a07645