### PR TITLE
Fix dealer button missing after loading saved game

### DIFF
--- a/src/store/gameStore.loadDealer.test.ts
+++ b/src/store/gameStore.loadDealer.test.ts
@@ -1,0 +1,42 @@
+import useGameStore from './gameStore';
+import { BettingLimit } from '../models/Game';
+
+beforeEach(() => {
+  useGameStore.setState({
+    currentGame: null,
+    gameHistory: [],
+    historyIndex: -1,
+    savedGames: [],
+    playerStats: new Map(),
+    stacksBeforeHand: null,
+    handHistory: [],
+    currentHandStats: null
+  });
+  localStorage.clear();
+});
+
+describe('loading preserved dealer', () => {
+  test('restores dealer from dealerPosition when flag missing', () => {
+    const store = useGameStore.getState();
+    store.createNewGame({ startingStack: 100, smallBlind: 5, bigBlind: 10, bettingLimit: BettingLimit.NO_LIMIT });
+    store.addPlayer('Alice');
+    store.addPlayer('Bob');
+    const bob = useGameStore.getState().currentGame!.players[1];
+
+    // Save the game
+    store.saveGame('test');
+    const savedGames = JSON.parse(localStorage.getItem('poker_saved_games')!);
+    const gameState = JSON.parse(savedGames[0].gameState);
+    // Remove isDealer flags to simulate old save format
+    gameState.players.forEach((p: any) => delete p.isDealer);
+    savedGames[0].gameState = JSON.stringify(gameState);
+    localStorage.setItem('poker_saved_games', JSON.stringify(savedGames));
+
+    // Load and verify dealer
+    store.loadGame(savedGames[0].id);
+    const loadedGame = useGameStore.getState().currentGame!;
+    const dealer = loadedGame.players[loadedGame.dealerPosition];
+    expect(dealer.id).toBe(bob.id);
+    expect(dealer.isDealer).toBe(true);
+  });
+});

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -163,7 +163,7 @@ const deserializeGame = (gameString: string): Game => {
       return player;
     });
   }
-  
+
   // Recreate PotManager instance with proper prototype
   const potManager = new PotManager();
   if (gameData.potManager) {
@@ -181,7 +181,20 @@ const deserializeGame = (gameString: string): Game => {
     }
   }
   game.potManager = potManager;
-  
+
+  // Ensure dealer information is preserved
+  if (game.players && game.players.length > 0) {
+    const dealerIndex = game.players.findIndex(p => p.isDealer);
+    if (dealerIndex >= 0) {
+      game.dealerPosition = dealerIndex;
+    } else if (typeof game.dealerPosition === 'number' && game.players[game.dealerPosition]) {
+      game.players[game.dealerPosition].isDealer = true;
+    } else {
+      game.players[0].isDealer = true;
+      game.dealerPosition = 0;
+    }
+  }
+
   return game;
 };
 


### PR DESCRIPTION
## Summary
- ensure `deserializeGame` reconstructs dealer info when loading a saved game
- add test covering dealer restoration from saved games without `isDealer`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c191c00334832dabcf53b2cacfdaa8