### PR TITLE
Refine pot-size raise logic and tests

### DIFF
--- a/src/components/ActionButtons.tsx
+++ b/src/components/ActionButtons.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { ActionType, BettingLimit } from '../models/Game';
 import { Player } from '../models/Player';
+import { calculatePotSizeRaise } from '../utils/betUtils';
 import './ActionButtons.css';
 
 interface ActionButtonsProps {
@@ -64,9 +65,9 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
     
     // Calculate max raise based on betting limit
     if (bettingLimit === BettingLimit.POT_LIMIT) {
-      // In pot limit, max raise is pot size after calling
-      const potAfterCall = potSize + (currentBet - currentPlayer.currentBet);
-      maxRaise = Math.min(currentBet + potAfterCall, currentPlayer.stack + currentPlayer.currentBet);
+      // In pot limit, max raise is a pot-sized raise
+      const potRaise = calculatePotSizeRaise(potSize, currentBet);
+      maxRaise = Math.min(potRaise, currentPlayer.stack + currentPlayer.currentBet);
     } else if (bettingLimit === BettingLimit.FIXED_LIMIT) {
       // In fixed limit, raise is exactly minRaise (or all-in if less)
       maxRaise = Math.min(currentBet + minRaise, currentPlayer.stack + currentPlayer.currentBet);
@@ -221,18 +222,25 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
                 <div className="quick-bets">
                   {bettingLimit === BettingLimit.POT_LIMIT ? (
                     <>
-                      <button 
+                      <button
                         className="quick-bet-button pot-raise"
                         onClick={() => {
-                          const potAfterCall = potSize + (currentBet - currentPlayer.currentBet);
-                          const potRaise = currentBet + potAfterCall;
+                          const potRaise = calculatePotSizeRaise(
+                            potSize,
+                            currentBet
+                          );
                           setRaiseAmount(potRaise.toString());
                         }}
                       >
                         <span className="quick-bet-label">POT</span>
                         <span className="quick-bet-amount">
-                          ${Math.min(currentBet + potSize + (currentBet - currentPlayer.currentBet), 
-                                     currentPlayer.stack + currentPlayer.currentBet)}
+                          ${Math.min(
+                            calculatePotSizeRaise(
+                              potSize,
+                              currentBet
+                            ),
+                            currentPlayer.stack + currentPlayer.currentBet
+                          )}
                         </span>
                       </button>
                     </>
@@ -251,9 +259,11 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
                   value={raiseAmount}
                   onChange={e => setRaiseAmount(e.target.value)}
                   placeholder={`Min: ${Math.min(currentBet + minRaise, currentPlayer.stack + currentPlayer.currentBet)}, Max: ${
-                    bettingLimit === BettingLimit.POT_LIMIT 
-                      ? Math.min(currentBet + potSize + (currentBet - currentPlayer.currentBet), 
-                                 currentPlayer.stack + currentPlayer.currentBet)
+                    bettingLimit === BettingLimit.POT_LIMIT
+                      ? Math.min(
+                          calculatePotSizeRaise(potSize, currentBet),
+                          currentPlayer.stack + currentPlayer.currentBet
+                        )
                       : currentPlayer.stack + currentPlayer.currentBet
                   }`}
                   autoFocus

--- a/src/utils/betUtils.test.ts
+++ b/src/utils/betUtils.test.ts
@@ -1,0 +1,21 @@
+import { calculatePotSizeRaise } from './betUtils';
+
+describe('calculatePotSizeRaise', () => {
+  test('pre-flop initial raise from first player', () => {
+    // Pot: SB 1 + BB 2 = 3, current bet 2
+    const raiseTo = calculatePotSizeRaise(3, 2);
+    expect(raiseTo).toBe(7);
+  });
+
+  test('player raising after another player calls', () => {
+    // Pot is 5 after a call, current bet still 2
+    const raiseTo = calculatePotSizeRaise(5, 2);
+    expect(raiseTo).toBe(9);
+  });
+
+  test('pot-sized reraise after pot-sized raise', () => {
+    // Pot is 10 after a raise to 7
+    const raiseTo = calculatePotSizeRaise(10, 7);
+    expect(raiseTo).toBe(24);
+  });
+});

--- a/src/utils/betUtils.ts
+++ b/src/utils/betUtils.ts
@@ -1,0 +1,11 @@
+// In pot-limit games, a "pot-sized" raise is computed as the size of the pot
+// before the player acts plus twice the current bet. This approach matches the
+// common heuristic of taking three times the last bet and adding the prior pot.
+//
+// Examples:
+// - Starting pot of 3 (1 SB + 2 BB), current bet 2 -> raise to 7
+// - Pot of 5 after a call, current bet 2 -> raise to 9
+// - Pot of 10 after a raise to 7 -> re-raise to 24
+export function calculatePotSizeRaise(potSize: number, currentBet: number): number {
+  return potSize + 2 * currentBet;
+}


### PR DESCRIPTION
## Summary
- refine pot-size raise formula to match pot-limit heuristics
- expand tests for pot-size bets and re-raises
- wire ActionButtons to new helper for consistent pot-limit raises

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1ac7403f4832da3e8703b4255a533