### PR TITLE
Fix pot-size raise formula and tests

### DIFF
--- a/src/components/ActionButtons.tsx
+++ b/src/components/ActionButtons.tsx
@@ -32,7 +32,7 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
   const canCall = currentBet > currentPlayer.currentBet && currentPlayer.stack > 0;
   const canBet = currentBet === 0 && currentPlayer.stack >= Math.min(minBet, currentPlayer.stack);
   const canRaise = currentBet > 0 && currentPlayer.stack > (currentBet - currentPlayer.currentBet);
-  const callAmount = Math.min(currentBet - currentPlayer.currentBet, currentPlayer.stack);
+  const callAmount = Math.max(0, Math.min(currentBet - currentPlayer.currentBet, currentPlayer.stack));
 
   const handleBet = () => {
     const amount = parseInt(betAmount);
@@ -66,7 +66,7 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
     // Calculate max raise based on betting limit
     if (bettingLimit === BettingLimit.POT_LIMIT) {
       // In pot limit, max raise is a pot-sized raise
-      const potRaise = calculatePotSizeRaise(potSize, currentBet);
+      const potRaise = calculatePotSizeRaise(potSize, currentBet, callAmount);
       maxRaise = Math.min(potRaise, currentPlayer.stack + currentPlayer.currentBet);
     } else if (bettingLimit === BettingLimit.FIXED_LIMIT) {
       // In fixed limit, raise is exactly minRaise (or all-in if less)
@@ -227,7 +227,8 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
                         onClick={() => {
                           const potRaise = calculatePotSizeRaise(
                             potSize,
-                            currentBet
+                            currentBet,
+                            callAmount
                           );
                           setRaiseAmount(potRaise.toString());
                         }}
@@ -237,7 +238,8 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
                           ${Math.min(
                             calculatePotSizeRaise(
                               potSize,
-                              currentBet
+                              currentBet,
+                              callAmount
                             ),
                             currentPlayer.stack + currentPlayer.currentBet
                           )}
@@ -261,7 +263,7 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
                   placeholder={`Min: ${Math.min(currentBet + minRaise, currentPlayer.stack + currentPlayer.currentBet)}, Max: ${
                     bettingLimit === BettingLimit.POT_LIMIT
                       ? Math.min(
-                          calculatePotSizeRaise(potSize, currentBet),
+                          calculatePotSizeRaise(potSize, currentBet, callAmount),
                           currentPlayer.stack + currentPlayer.currentBet
                         )
                       : currentPlayer.stack + currentPlayer.currentBet

--- a/src/utils/betUtils.test.ts
+++ b/src/utils/betUtils.test.ts
@@ -2,20 +2,32 @@ import { calculatePotSizeRaise } from './betUtils';
 
 describe('calculatePotSizeRaise', () => {
   test('pre-flop initial raise from first player', () => {
-    // Pot: SB 1 + BB 2 = 3, current bet 2
-    const raiseTo = calculatePotSizeRaise(3, 2);
+    // Pot: SB 1 + BB 2 = 3, current bet 2, call 2
+    const raiseTo = calculatePotSizeRaise(3, 2, 2);
     expect(raiseTo).toBe(7);
   });
 
   test('player raising after another player calls', () => {
-    // Pot is 5 after a call, current bet still 2
-    const raiseTo = calculatePotSizeRaise(5, 2);
+    // Pot is 5 after a call, current bet still 2, call 2
+    const raiseTo = calculatePotSizeRaise(5, 2, 2);
     expect(raiseTo).toBe(9);
   });
 
   test('pot-sized reraise after pot-sized raise', () => {
-    // Pot is 10 after a raise to 7
-    const raiseTo = calculatePotSizeRaise(10, 7);
+    // Pot is 10 after a raise to 7, call 7
+    const raiseTo = calculatePotSizeRaise(10, 7, 7);
     expect(raiseTo).toBe(24);
+  });
+
+  test('small blind facing pot-sized raise', () => {
+    // Pot 10, current bet 7, SB has 1 in so call is 6
+    const raiseTo = calculatePotSizeRaise(10, 7, 6);
+    expect(raiseTo).toBe(23);
+  });
+
+  test('big blind facing pot-sized raise', () => {
+    // Pot 10, current bet 7, BB has 2 in so call is 5
+    const raiseTo = calculatePotSizeRaise(10, 7, 5);
+    expect(raiseTo).toBe(22);
   });
 });

--- a/src/utils/betUtils.ts
+++ b/src/utils/betUtils.ts
@@ -1,11 +1,20 @@
-// In pot-limit games, a "pot-sized" raise is computed as the size of the pot
-// before the player acts plus twice the current bet. This approach matches the
-// common heuristic of taking three times the last bet and adding the prior pot.
+// In pot-limit games, a "pot-sized" raise is the sum of:
+//   • the size of the pot before the player acts
+//   • the last outstanding bet
+//   • the amount the player must call to match the current bet
+// This formula properly accounts for blinds and any chips the player has already
+// committed to the pot.
 //
 // Examples:
-// - Starting pot of 3 (1 SB + 2 BB), current bet 2 -> raise to 7
-// - Pot of 5 after a call, current bet 2 -> raise to 9
-// - Pot of 10 after a raise to 7 -> re-raise to 24
-export function calculatePotSizeRaise(potSize: number, currentBet: number): number {
-  return potSize + 2 * currentBet;
+// - Starting pot of 3 (1 SB + 2 BB), current bet 2, call 2 -> raise to 7
+// - Pot of 5 after a call, current bet 2, call 2       -> raise to 9
+// - Pot of 10 after a raise to 7, call 7              -> raise to 24
+// - Small blind facing raise to 7: pot 10, call 6     -> raise to 23
+// - Big blind facing raise to 7: pot 10, call 5       -> raise to 22
+export function calculatePotSizeRaise(
+  potSize: number,
+  currentBet: number,
+  callAmount: number
+): number {
+  return potSize + currentBet + callAmount;
 }


### PR DESCRIPTION
## Summary
- correct pot-limit raise calculation to include pot, outstanding bet, and call amount
- update action buttons to use revised pot-size raise logic
- expand bet size tests for blinds and general cases

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1ca9671a0832dbc007083efbadc03